### PR TITLE
Remove slash from file location on example

### DIFF
--- a/content/_examples/pypi.html
+++ b/content/_examples/pypi.html
@@ -46,7 +46,7 @@ Your package has now been built as a source tarball and is ready to be uploaded.
 
 {% example %}
 
-    binstar upload /dist/*.tar.gz
+    binstar upload dist/*.tar.gz
 
 {% endsection %}
 {% section %}


### PR DESCRIPTION
When following the guide, on the PyPi packages section you can read:
```
binstar upload /dist/*.tar.gz
```
when it should be:
```
binstar upload dist/*.tar.gz
```
The path should be relative